### PR TITLE
Added Temperature Sensor

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -31,6 +31,18 @@
             "required": true
           }
         }
+      },
+      "hideTemperatureSensor": {
+        "title": "Hide Temperature Sensor",
+        "type": "boolean",
+        "default": false,
+        "description": "Enable this option to hide the temperature sensor."
+      },
+      "temperatureOffset": {
+        "title": "Temperature Offset",
+        "type": "number",
+        "default": 0,
+        "description": "Subtract (or add) a set amount from the temperature reading. (Use negative numbers to subtract.)"
       }
     }
   }

--- a/config.schema.json
+++ b/config.schema.json
@@ -41,9 +41,30 @@
       "temperatureOffset": {
         "title": "Temperature Offset",
         "type": "number",
+        "condition": {
+          "functionBody": "return model.hideTemperatureSensor === false;"
+        },
         "default": 0,
         "description": "Subtract (or add) a set amount from the temperature reading. (Use negative numbers to subtract.)"
       }
     }
-  }
+  },
+  "form": [
+    {
+      "type": "fieldset",
+      "title": "Dreo App Login",
+      "items": [
+        "options.email",
+        "options.password"
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Temperature Sensor",
+      "items": [
+        "hideTemperatureSensor",
+        "temperatureOffset"
+      ]
+    }
+  ]
 }

--- a/src/FanAccessory.ts
+++ b/src/FanAccessory.ts
@@ -201,6 +201,6 @@ export class FanAccessory {
 
   async getTemperature() {
     const offset = this.platform.config.temperatureOffset || 0; // default to 0 if not defined
-    return this.fanState.Temperature - offset;
+    return this.fanState.Temperature + offset;
   }
 }

--- a/src/FanAccessory.ts
+++ b/src/FanAccessory.ts
@@ -8,6 +8,7 @@ import { DreoPlatform } from './platform';
  */
 export class FanAccessory {
   private service: Service;
+  private temperatureService?: Service;
 
   // Cached copy of latest fan states
   private fanState = {
@@ -16,6 +17,7 @@ export class FanAccessory {
     Swing: false,
     SwingMethod: 'shakehorizon',  // some fans use hoscon instead of shakehorizon to control swing mode
     MaxSpeed: 1,
+    Temperature: 0,
   };
 
   constructor(
@@ -76,6 +78,30 @@ export class FanAccessory {
       this.fanState.Swing = state.shakehorizon.state;
     }
 
+    const shouldHideTemperatureSensor = this.platform.config.hideTemperatureSensor || false; // default to false if not defined
+
+    // If temperature is defined and we are not hiding the sensor
+    if (state.temperature !== undefined && !shouldHideTemperatureSensor) {
+      this.fanState.Temperature = state.temperature.state;
+
+      // Check if the Temperature Sensor service already exists, if not create a new one
+      this.temperatureService = this.accessory.getService(this.platform.Service.TemperatureSensor);
+
+      if (!this.temperatureService) {
+        this.temperatureService = this.accessory.addService(this.platform.Service.TemperatureSensor, 'Temperature Sensor');
+      }
+
+      // Bind the get handler for temperature to this service
+      this.temperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+        .onGet(this.getTemperature.bind(this));
+    } else {
+      const existingTemperatureService = this.accessory.getService(this.platform.Service.TemperatureSensor);
+      if (existingTemperatureService) {
+        platform.log.debug('Hiding Temperature Sensor');
+        this.accessory.removeService(existingTemperatureService);
+      }
+    }
+
     // update values from Dreo app
     ws.addEventListener('message', message => {
       const data = JSON.parse(message.data);
@@ -102,6 +128,10 @@ export class FanAccessory {
             case 'hoscon':
               this.fanState.Swing = data.reported.hoscon;
               this.platform.log.debug('Oscillation mode:', data.reported.hoscon);
+              break;
+            case 'temperature':
+              this.fanState.Temperature = data.reported.temperature;
+              this.platform.log.debug('Temperature:', data.reported.temperature);
               break;
             default:
               platform.log.debug('Unknown command received:', Object.keys(data.reported)[0]);
@@ -167,5 +197,10 @@ export class FanAccessory {
 
   async getSwingMode() {
     return this.fanState.Swing;
+  }
+
+  async getTemperature() {
+    const offset = this.platform.config.temperatureOffset || 0; // default to 0 if not defined
+    return this.fanState.Temperature - offset;
   }
 }


### PR DESCRIPTION
Per issue [#18](https://github.com/zyonse/homebridge-dreo/issues/18), I have added a temperature sensor. This is optional, and there is also an option to provide a set temperature offset since the Dreo Temperature sensors are pretty inaccurate. 