### PR TITLE
Fix HomeBridge crash for fans with no shakehorizon state

### DIFF
--- a/src/FanAccessory.ts
+++ b/src/FanAccessory.ts
@@ -73,7 +73,7 @@ export class FanAccessory {
       this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
         .onSet(this.setSwingMode.bind(this))
         .onGet(this.getSwingMode.bind(this));
-      this.fanState.Swing = state.shakehorizon.state;
+      this.fanState.Swing = state[this.fanState.SwingMethod].state;
     }
 
     // update values from Dreo app


### PR DESCRIPTION
On a fan like DR-HAF003S, the plugin (git head) crashes HomeBridge on startup:

```
[10/10/2023, 7:33:04 PM] TypeError: Cannot read properties of undefined (reading 'state')
    at new FanAccessory (/homebridge/node_modules/homebridge-dreo/src/FanAccessory.ts:76:48)
    at DreoPlatform.discoverDevices (/homebridge/node_modules/homebridge-dreo/src/platform.ts:131:9)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This is because the plugin tries to read the `shakehorizon` key, even when only `hoscon` exists.

This fix ensures we only read one or the other.