### PR TITLE
Force HomeKit update when values change upstream

### DIFF
--- a/src/FanAccessory.ts
+++ b/src/FanAccessory.ts
@@ -89,18 +89,22 @@ export class FanAccessory {
           switch(Object.keys(data.reported)[0]) {
             case 'poweron':
               this.fanState.On = data.reported.poweron;
+              this.service.getCharacteristic(this.platform.Characteristic.Active).updateValue(this.fanState.On);
               this.platform.log.debug('Fan power:', data.reported.poweron);
               break;
             case 'windlevel':
               this.fanState.Speed = data.reported.windlevel * 100 / this.fanState.MaxSpeed;
+              this.service.getCharacteristic(this.platform.Characteristic.RotationSpeed).updateValue(this.fanState.Speed);
               this.platform.log.debug('Fan speed:', data.reported.windlevel);
               break;
             case 'shakehorizon':
               this.fanState.Swing = data.reported.shakehorizon;
+              this.service.getCharacteristic(this.platform.Characteristic.SwingMode).updateValue(this.fanState.Swing);
               this.platform.log.debug('Oscillation mode:', data.reported.shakehorizon);
               break;
             case 'hoscon':
               this.fanState.Swing = data.reported.hoscon;
+              this.service.getCharacteristic(this.platform.Characteristic.SwingMode).updateValue(this.fanState.Swing);
               this.platform.log.debug('Oscillation mode:', data.reported.hoscon);
               break;
             default:


### PR DESCRIPTION
While upstream Dreo app setting updates are reflected in the internal state of `FanAccessory`, this is not enough to trigger an update in HomeKit, which happen later, such as when refreshing the app, or when reloading the Accessories page in HomeBridge UI.

This change explicitly calls [`updateValue`](https://developers.homebridge.io/#/api/characteristics#characteristicupdatevalue) on the corresponding characteristic in response to this external trigger, which causes the accessory state to update instantaneously.

Tested this with DR-HAF003S on a local Homebridge installation.