### PR TITLE
Fix temperature units and make HomeKit updates consistent

### DIFF
--- a/src/FanAccessory.ts
+++ b/src/FanAccessory.ts
@@ -82,7 +82,7 @@ export class FanAccessory {
 
     // If temperature is defined and we are not hiding the sensor
     if (state.temperature !== undefined && !shouldHideTemperatureSensor) {
-      this.fanState.Temperature = state.temperature.state;
+      this.fanState.Temperature = this.correctedTemperature(state.temperature.state);
 
       // Check if the Temperature Sensor service already exists, if not create a new one
       this.temperatureService = this.accessory.getService(this.platform.Service.TemperatureSensor);
@@ -134,7 +134,7 @@ export class FanAccessory {
               this.platform.log.debug('Oscillation mode:', data.reported.hoscon);
               break;
             case 'temperature':
-              this.fanState.Temperature = data.reported.temperature;
+              this.fanState.Temperature = this.correctedTemperature(data.reported.temperature);
               this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature).updateValue(this.fanState.Temperature);
               this.platform.log.debug('Temperature:', data.reported.temperature);
               break;
@@ -205,7 +205,12 @@ export class FanAccessory {
   }
 
   async getTemperature() {
+    return this.fanState.Temperature;
+  }
+
+  correctedTemperature(temperatureFromDreo) {
     const offset = this.platform.config.temperatureOffset || 0; // default to 0 if not defined
-    return this.fanState.Temperature + offset;
+    // Dreo response is always Fahrenheit - convert to Celsius which is what HomeKit expects
+    return ((temperatureFromDreo + offset) - 32) * 5 / 9;
   }
 }


### PR DESCRIPTION
Dreo returns temperature in Fahrenheit units only, and Homebridge accepts temperature updates in Celsius only, so we need to convert between the two - discussion on #19.

Also fixes an issue where the HomeKit value updates in response to a Dreo update would drop the offset. Now offset correction is moved from read-time to write-time, ensuring that `this.fanState.Temperature` is always consistent.