### PR TITLE
feat(auth): Improve authentication to fail with wrong password

### DIFF
--- a/src/DreoAPI.ts
+++ b/src/DreoAPI.ts
@@ -30,7 +30,14 @@ export default class DreoAPI {
       },
     })
       .then((response) => {
-        token = response.data.data;
+        const payload = response.data;
+        if (payload.data && payload.data.access_token) {
+          // Auth success
+          token = payload.data;
+        } else {
+          platform.log.error('error retrieving token:', payload.msg);
+          token = undefined;
+        }
       })
       .catch((error) => {
         platform.log.error('error retrieving token:', error);


### PR DESCRIPTION
This change should improve the authentication handling to detect scenarios when the provided password is not valid, in which the API will return 200 and the following response payload:
```
{
    "code": 100022,
    "msg": "Incorrect account or password"
}
```

Another scenario is if the provided timestamp is not correct / accepted, in which the API will also return 200 and the following response payload:
```
{
    "code": 100030,
    "msg": "Your system clock is incorrect. Please set your clock to the current date and time."
}
```
