### PR TITLE
Initial support for Heaters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Please open an issue if you have another model that works or doesn't work. If yo
 * **Fan Speed:** Fan speed is displayed as a percentage value with steps that are equivalent to those of the Dreo app. (for example, a fan with speeds 1-6 will have steps at 17%, 33%, 50% etc)
 
 * **Oscillate:** Toggles fan oscillation
-* **Temperature Sensor:** Display the temperature sensor detected within your devices (for supported devices, check your devices capabilities)Because the Dreo fan temperature sensors are not entirely accurate, you can also set a specific temperature offset for your devices
+* **Temperature Sensor:** Displays current temperature sensor reading. (for supported devices, check your devices capabilities) Because the Dreo fan temperature sensors are not entirely accurate, you can also set a specific temperature offset for your devices.
 * **Child Lock:** Lock physical fan controls
 
 ### Heaters
@@ -60,6 +60,7 @@ Please open an issue if you have another model that works or doesn't work. If yo
 
 * **Heat Mode:** Controls Dreo 'Eco' mode
 * **Cool Mode:** Controls Dreo 'Fan Only' mode
+* **Auto Mode:** Controls Dreo 'Heat' speeds, represented as an offset from the minimum temperature (for example, a heater with speeds 1-3 and a minimum temp of 41F can be controlled by setting temperature to 41, 42, 43)
 * **Current Temperature:** Displays current temperature sensor reading
 * **Fan Speed:** Controls heater vent angle
 * **Oscillate:** Toggles heater vent oscillation

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 # Homebridge Dreo Plugin
+
 [![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
 [![NPM Version](https://img.shields.io/npm/v/homebridge-dreo.svg)](https://www.npmjs.com/package/homebridge-dreo)
 [![npm](https://img.shields.io/npm/dt/homebridge-dreo)](https://www.npmjs.com/package/homebridge-dreo)
@@ -15,35 +16,68 @@ Homebridge plugin for Dreo brand smart devices. [Dreo Fans on Amazon](https://ww
 </p>
 
 ## Compatability
+
 ### Confirmed Working
+
 #### Tower Fans
+
 * DR-HTF001S
 * DR-HTF002S
 * DR-HTF004S
 * DR-HTF005S
 * DR-HTF007S
+
 #### Pedestal Fans
+
 * DR-HPF001S
 * DR-HPF002S
 * DR-HAF003S
+
 #### Table Fans
+
 * DR-HAF001S
 * DR-HAF004S
 
-Please open an issue if you have another model that works or doesn't work. The plugin *should* also be compatible with multiple devices on the same account but I haven't tested this. Non-fan smart devices are not supported at this time, but if you have another device and can help me test some code out I would definitely be open to adding support.
+#### Wall-mounted Heaters
 
-## Features
-- **Temperature Sensor Display:** Display the temperature sensor detected within your devices (for supported devices, check your devices capabilities). Because the Dreo devices temperature sensors are not entirely accurate, you can also set a specific temperature offset for your devices.
+* DR-HSH009S
+
+Please open an issue if you have another model that works or doesn't work. If you have another device type and can help me test some code out I would definitely be open to adding support.
+
+## Supported Features
+
+### Fans
+
+* **Fan Speed:** Fan speed is displayed as a percentage value with steps that are equivalent to those of the Dreo app. (for example, a fan with speeds 1-6 will have steps at 17%, 33%, 50% etc)
+
+* **Oscillate:** Toggles fan oscillation
+* **Temperature Sensor:** Display the temperature sensor detected within your devices (for supported devices, check your devices capabilities)Because the Dreo fan temperature sensors are not entirely accurate, you can also set a specific temperature offset for your devices
+* **Child Lock:** Lock physical fan controls
+
+### Heaters
+
+#### Heaters are displayed as a thermostat accessory with the following control mappings
+
+* **Heat Mode:** Controls Dreo 'Eco' mode
+* **Cool Mode:** Controls Dreo 'Fan Only' mode
+* **Current Temperature:** Displays current temperature sensor reading
+* **Fan Speed:** Controls heater vent angle
+* **Oscillate:** Toggles heater vent oscillation
+* **Child Lock:** Lock physical heater controls
+* **Hardware Display:** Changes temperature unit on physical hardware display
 
 ## Installation
-```
+
+```bash
 npm install -g homebridge-dreo
 ```
 
 (Or install through the Homebridge UI)
 
 ## Configuration
+
 Provide your Dreo app login credentials
+
 ```json
 "platforms": [
   {
@@ -60,9 +94,11 @@ Provide your Dreo app login credentials
 ```
 
 ## Contributing
+
 If you'd like to add support for a new device type, you might find this writeup from [@JeffSteinbok](https://github.com/JeffSteinbok) (HomeAssistant plugin maintainer) useful for tracing the Dreo App:
 
 https://github.com/JeffSteinbok/hass-dreo/blob/main/contributing.md
 
 ## Special thanks
+
 [homebridge-tp-link-tapo](https://github.com/RaresAil/homebridge-tp-link-tapo): Similar repo that helped me figure out some of the http request functions necessary for this project.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Homebridge plugin for Dreo brand smart devices. [Dreo Fans on Amazon](https://ww
   <img src="https://github.com/zyonse/homebridge-dreo/assets/28782587/1f1d85e6-5bbf-46b5-be7f-6edf95727327" width=200>
   <img src="https://github.com/zyonse/homebridge-dreo/assets/28782587/d5095dd8-3dbe-4f31-9309-1b37c6f62eeb" width=200>
 </p>
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/81bd06d3-5a40-4516-9cf0-bacbd704e689" width=200>
+  <img src="https://github.com/user-attachments/assets/25488e2a-3ac7-4370-9912-072dae31d7d5" width=200>
+  <img src="https://github.com/user-attachments/assets/17e6350d-ec68-48e8-88da-3bd553dffbf2" width=200>
+</p>
 
 ## Compatability
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -36,19 +36,19 @@
         }
       },
       "hideTemperatureSensor": {
-        "title": "Hide Temperature Sensor",
+        "title": "Hide Fan Temperature Sensor",
         "type": "boolean",
         "default": false,
         "description": "Enable this option to hide the temperature sensor."
       },
       "temperatureOffset": {
-        "title": "Temperature Offset",
+        "title": "Fan Temperature Offset",
         "type": "number",
         "condition": {
           "functionBody": "return model.hideTemperatureSensor === false;"
         },
         "default": 0,
-        "description": "Subtract (or add) a set amount from the temperature reading. (Use negative numbers to subtract.)"
+        "description": "Subtract (or add) a set amount from the temperature reading (use negative numbers to subtract). This setting only applies to fans."
       }
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-dreo",
-  "version": "3.4.1",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-dreo",
-      "version": "3.4.1",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-dreo",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-dreo",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Dreo",
   "name": "homebridge-dreo",
-  "version": "3.4.1",
+  "version": "4.0.0",
   "description": "Homebridge Plugin for Dreo Smart Devices",
   "homepage": "https://github.com/zyonse/homebridge-dreo",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Dreo",
   "name": "homebridge-dreo",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Homebridge Plugin for Dreo Smart Devices",
   "homepage": "https://github.com/zyonse/homebridge-dreo",
   "license": "Apache-2.0",

--- a/src/DreoAPI.ts
+++ b/src/DreoAPI.ts
@@ -19,8 +19,8 @@ export default class DreoAPI {
 
   constructor(platform: DreoPlatform) {
     this.log = platform.log;
-    this.email = platform.config.options.email;
-    this.password = platform.config.options.password;
+    this.email = platform.config.options?.email;
+    this.password = platform.config.options?.password;
     this.server = 'us';
     this.access_token = '';
   }

--- a/src/accessories/BaseAccessory.ts
+++ b/src/accessories/BaseAccessory.ts
@@ -2,7 +2,7 @@ import { PlatformAccessory } from 'homebridge';
 import { DreoPlatform } from '../platform';
 
 export abstract class BaseAccessory {
-  protected readonly sn = this.accessory.context.sn;
+  protected readonly sn = this.accessory.context.device.sn;
 
   constructor(
     protected readonly platform: DreoPlatform,

--- a/src/accessories/BaseAccessory.ts
+++ b/src/accessories/BaseAccessory.ts
@@ -16,6 +16,6 @@ export abstract class BaseAccessory {
   }
 
   // Abstract methods that derived classes must implement
-  abstract handleActiveSet(value: boolean): void;
-  abstract handleActiveGet(): boolean;
+  abstract setActive(value: boolean): void;
+  abstract getActive(): boolean;
 }

--- a/src/accessories/BaseAccessory.ts
+++ b/src/accessories/BaseAccessory.ts
@@ -1,0 +1,21 @@
+import { PlatformAccessory } from 'homebridge';
+import { DreoPlatform } from '../platform';
+
+export abstract class BaseAccessory {
+  protected readonly sn = this.accessory.context.sn;
+
+  constructor(
+    protected readonly platform: DreoPlatform,
+    protected readonly accessory: PlatformAccessory,
+  ) {
+    // Set accessory information
+    accessory.getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, accessory.context.device.brand)
+      .setCharacteristic(this.platform.Characteristic.Model, accessory.context.device.model)
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, accessory.context.device.sn);
+  }
+
+  // Abstract methods that derived classes must implement
+  abstract handleActiveSet(value: boolean): void;
+  abstract handleActiveGet(): boolean;
+}

--- a/src/accessories/FanAccessory.ts
+++ b/src/accessories/FanAccessory.ts
@@ -137,66 +137,68 @@ export class FanAccessory extends BaseAccessory {
 
         // Check if we need to update fan state in homekit
         if (data.method === 'control-report' || data.method === 'control-reply' || data.method === 'report') {
-          switch(Object.keys(data.reported)[0]) {
-            case 'poweron':
-              this.currState.on = data.reported.poweron;
-              this.service.getCharacteristic(this.platform.Characteristic.Active)
-                .updateValue(this.currState.on);
-              this.platform.log.debug('Fan power:', data.reported.poweron);
-              break;
-            case 'fanon':
-              this.currState.on = data.reported.fanon;
-              this.service.getCharacteristic(this.platform.Characteristic.Active)
-                .updateValue(this.currState.on);
-              this.platform.log.debug('Fan power:', data.reported.fanon);
-              break;
-            case 'windlevel':
-              this.currState.speed = data.reported.windlevel * 100 / this.currState.maxSpeed;
-              this.service.getCharacteristic(this.platform.Characteristic.RotationSpeed)
-                .updateValue(this.currState.speed);
-              this.platform.log.debug('Fan speed:', data.reported.windlevel);
-              break;
-            case 'shakehorizon':
-              this.currState.swing = data.reported.shakehorizon;
-              this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
-                .updateValue(this.currState.swing);
-              this.platform.log.debug('Oscillation mode:', data.reported.shakehorizon);
-              break;
-            case 'hoscon':
-              this.currState.swing = data.reported.hoscon;
-              this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
-                .updateValue(this.currState.swing);
-              this.platform.log.debug('Oscillation mode:', data.reported.hoscon);
-              break;
-            case 'oscmode':
-              this.currState.swing = Boolean(data.reported.oscmode);
-              this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
-                .updateValue(this.currState.swing);
-              this.platform.log.debug('Oscillation mode:', data.reported.oscmode);
-              break;
-            case 'mode':
-              this.currState.autoMode = this.convertModeToBoolean(data.reported.mode);
-              this.service.getCharacteristic(this.platform.Characteristic.TargetFanState)
-                .updateValue(this.currState.autoMode);
-              this.platform.log.debug('Fan mode:', data.reported.mode);
-              break;
-            case 'childlockon':
-              this.currState.lockPhysicalControls = Boolean(data.reported.childlockon);
-              this.service.getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
-                .updateValue(this.currState.lockPhysicalControls);
-              this.platform.log.debug('Child lock:', data.reported.childlockon);
-              break;
-            case 'temperature':
-              if (this.temperatureService !== undefined && !shouldHideTemperatureSensor) {
-                this.currState.temperature = this.correctedTemperature(data.reported.temperature);
-                this.temperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
-                  .updateValue(this.currState.temperature);
-              }
-              this.platform.log.debug('Temperature:', data.reported.temperature);
-              break;
-            default:
-              platform.log.debug('Unknown command received:', Object.keys(data.reported)[0]);
-          }
+          Object.keys(data.reported).forEach(key => {
+            switch(key) {
+              case 'poweron':
+                this.currState.on = data.reported.poweron;
+                this.service.getCharacteristic(this.platform.Characteristic.Active)
+                  .updateValue(this.currState.on);
+                this.platform.log.debug('Fan power:', data.reported.poweron);
+                break;
+              case 'fanon':
+                this.currState.on = data.reported.fanon;
+                this.service.getCharacteristic(this.platform.Characteristic.Active)
+                  .updateValue(this.currState.on);
+                this.platform.log.debug('Fan power:', data.reported.fanon);
+                break;
+              case 'windlevel':
+                this.currState.speed = data.reported.windlevel * 100 / this.currState.maxSpeed;
+                this.service.getCharacteristic(this.platform.Characteristic.RotationSpeed)
+                  .updateValue(this.currState.speed);
+                this.platform.log.debug('Fan speed:', data.reported.windlevel);
+                break;
+              case 'shakehorizon':
+                this.currState.swing = data.reported.shakehorizon;
+                this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
+                  .updateValue(this.currState.swing);
+                this.platform.log.debug('Oscillation mode:', data.reported.shakehorizon);
+                break;
+              case 'hoscon':
+                this.currState.swing = data.reported.hoscon;
+                this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
+                  .updateValue(this.currState.swing);
+                this.platform.log.debug('Oscillation mode:', data.reported.hoscon);
+                break;
+              case 'oscmode':
+                this.currState.swing = Boolean(data.reported.oscmode);
+                this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
+                  .updateValue(this.currState.swing);
+                this.platform.log.debug('Oscillation mode:', data.reported.oscmode);
+                break;
+              case 'mode':
+                this.currState.autoMode = this.convertModeToBoolean(data.reported.mode);
+                this.service.getCharacteristic(this.platform.Characteristic.TargetFanState)
+                  .updateValue(this.currState.autoMode);
+                this.platform.log.debug('Fan mode:', data.reported.mode);
+                break;
+              case 'childlockon':
+                this.currState.lockPhysicalControls = Boolean(data.reported.childlockon);
+                this.service.getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
+                  .updateValue(this.currState.lockPhysicalControls);
+                this.platform.log.debug('Child lock:', data.reported.childlockon);
+                break;
+              case 'temperature':
+                if (this.temperatureService !== undefined && !shouldHideTemperatureSensor) {
+                  this.currState.temperature = this.correctedTemperature(data.reported.temperature);
+                  this.temperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+                    .updateValue(this.currState.temperature);
+                }
+                this.platform.log.debug('Temperature:', data.reported.temperature);
+                break;
+              default:
+                platform.log.debug('Unknown command received:', Object.keys(data.reported)[0]);
+            }
+          });
         }
       }
     });

--- a/src/accessories/FanAccessory.ts
+++ b/src/accessories/FanAccessory.ts
@@ -58,8 +58,8 @@ export class FanAccessory extends BaseAccessory {
     // See https://developers.homebridge.io/#/service/Fanv2
     // Register handlers for the Active Characteristic
     this.service.getCharacteristic(this.platform.Characteristic.Active)
-      .onSet(this.handleActiveSet.bind(this))
-      .onGet(this.handleActiveGet.bind(this));
+      .onSet(this.setActive.bind(this))
+      .onGet(this.getActive.bind(this));
 
     // Register handlers for the RotationSpeed Characteristic
     this.service.getCharacteristic(this.platform.Characteristic.RotationSpeed)
@@ -203,7 +203,7 @@ export class FanAccessory extends BaseAccessory {
   }
 
   // Handle requests to set the "Active" characteristic
-  handleActiveSet(value) {
+  setActive(value) {
     this.platform.log.debug('Triggered SET Active:', value);
     // Check state to prevent duplicate requests
     if (this.currState.on !== Boolean(value)) {
@@ -213,7 +213,7 @@ export class FanAccessory extends BaseAccessory {
   }
 
   // Handle requests to get the current value of the "Active" characteristic
-  handleActiveGet() {
+  getActive() {
     return this.currState.on;
   }
 

--- a/src/accessories/FanAccessory.ts
+++ b/src/accessories/FanAccessory.ts
@@ -1,5 +1,5 @@
 import { Service, PlatformAccessory} from 'homebridge';
-import { DreoPlatform } from './platform';
+import { DreoPlatform } from '../platform';
 
 /**
  * Platform Accessory

--- a/src/accessories/HeaterAccessory.ts
+++ b/src/accessories/HeaterAccessory.ts
@@ -89,7 +89,7 @@ export class HeaterAccessory extends BaseAccessory {
     this.service.getCharacteristic(this.platform.Characteristic.TargetHeaterCoolerState)
       .onSet(this.setTargetHeaterCoolerState.bind(this))
       .onGet(this.getTargetHeaterCoolerState.bind(this))
-      .setProps({
+      .setProps({  // Disable auto mode
         minValue: 1,
         maxValue: 2,
         validValues: [1, 2],
@@ -113,7 +113,7 @@ export class HeaterAccessory extends BaseAccessory {
     this.service.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
       .onSet(this.setCoolingThresholdTemperature.bind(this))
       .onGet(this.getCoolingThresholdTemperature.bind(this))
-      .setProps({
+      .setProps({  // Only allow single value for cooling mode
         minValue: 10,
         maxValue: 10,
         validValues: [10],

--- a/src/accessories/HeaterAccessory.ts
+++ b/src/accessories/HeaterAccessory.ts
@@ -114,9 +114,9 @@ export class HeaterAccessory extends BaseAccessory {
       .onSet(this.setCoolingThresholdTemperature.bind(this))
       .onGet(this.getCoolingThresholdTemperature.bind(this))
       .setProps({
-        minValue: 0,
-        maxValue: 0,
-        validValues: [0],
+        minValue: 10,
+        maxValue: 10,
+        validValues: [10],
       });
 
     // Register handlers for Lock Physical Controls
@@ -284,7 +284,7 @@ export class HeaterAccessory extends BaseAccessory {
   }
 
   getCoolingThresholdTemperature() {
-    return 0;
+    return 10;
   }
 
   // Turn child lock on/off

--- a/src/accessories/HeaterAccessory.ts
+++ b/src/accessories/HeaterAccessory.ts
@@ -1,0 +1,171 @@
+import { Service, PlatformAccessory} from 'homebridge';
+import { DreoPlatform } from '../platform';
+import { BaseAccessory } from './BaseAccessory';
+
+/**
+ * Platform Accessory
+ * An instance of this class is created for each accessory your platform registers
+ * Each accessory may expose multiple services of different service types.
+ */
+export class HeaterAccessory extends BaseAccessory {
+  private service: Service;
+
+  // Cached copy of latest device states
+  private on: boolean;
+  private mode: string;
+  private heatLevel: number;
+  private oscAngle: number;
+  private temperature: number;
+  private targetTemperature: number;
+  private tempOffset: number;
+  private tempUnit: number;
+  private childLockOn: boolean;
+
+  constructor(
+    platform: DreoPlatform,
+    accessory: PlatformAccessory,
+    private readonly state,
+  ) {
+    // Call base class constructor
+    super(platform, accessory);
+
+    // Initialize device values
+    // Get min/max temperature from Dreo API
+
+
+    // Update current state in homebridge from Dreo API
+    this.tempOffset = state.tempoffset.state;
+    this.temperature = this.convertToCelsius(state.temperature.state);
+    this.targetTemperature = state.ecolevel.state;
+    this.on = state.poweron.state;
+    this.mode = state.mode.state;
+    this.heatLevel = state.htalevel.state;
+    this.oscAngle = state.oscangle.state;
+    this.tempUnit = state.tempunit.state;
+    this.childLockOn = state.childlockon.state;
+
+    // Get the HeaterCooler service if it exists, otherwise create a new HeaterCooler service
+    this.service = this.accessory.getService(this.platform.Service.HeaterCooler) ||
+                   this.accessory.addService(this.platform.Service.HeaterCooler);
+
+    // Set the service name, this is what is displayed as the default name on the Home app
+    this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device.deviceName);
+
+    // Register handlers for the Active characteristic
+    this.service.getCharacteristic(this.platform.Characteristic.Active)
+      .onSet(this.setActive.bind(this))
+      .onGet(this.getActive.bind(this));
+
+    // Register handlers for the Current Temperature characteristic
+    this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+      .onGet(this.getCurrentTemperature.bind(this));
+
+    // Register handlers for Heating Threshold Temperature
+    const tempLimits = accessory.context.device.controlsConf.schedule.modes.find(params => params.value === 'eco').controls[0];
+    this.service.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
+      .onSet(this.setHeatingThresholdTemperature)
+      .onGet(this.getHeatingThresholdTemperature)
+      .setProps({
+        minValue: tempLimits.startValue,
+        maxValue: tempLimits.endValue,
+      });
+
+    // Check if child lock is supported
+    if (state.childlockon !== undefined) {
+      // Register handlers for Lock Physical Controls
+      this.service.getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
+        .onSet(this.setLockPhysicalControls.bind(this))
+        .onGet(this.getLockPhysicalControls.bind(this));
+    }
+
+    // Update values from Dreo app
+    platform.webHelper.addEventListener('message', message => {
+      const data = JSON.parse(message.data);
+
+      // Check if message applies to this device
+      if (data.devicesn === accessory.context.device.sn) {
+        platform.log.debug('Incoming %s', message.data);
+
+        // Check if we need to update fan state in homekit
+        if (data.method === 'control-report' || data.method === 'control-reply' || data.method === 'report') {
+          switch(Object.keys(data.reported)[0]) {
+            case 'poweron':
+              this.on = data.reported.poweron;
+              this.service.getCharacteristic(this.platform.Characteristic.Active)
+                .updateValue(this.on);
+              this.platform.log.debug('Heater power:', data.reported.poweron);
+              break;
+            case 'mode':
+              this.mode = data.reported.mode;
+              this.service.getCharacteristic(this.platform.Characteristic.TargetFanState)
+                .updateValue(this.mode);
+              this.platform.log.debug('Fan mode:', data.reported.mode);
+              break;
+            case 'childlockon':
+              this.childLockOn = Boolean(data.reported.childlockon);
+              this.service.getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
+                .updateValue(this.childLockOn);
+              this.platform.log.debug('Child lock:', data.reported.childlockon);
+              break;
+            case 'temperature':
+              this.temperature = this.convertToCelsius(data.reported.temperature);
+              this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+                .updateValue(this.temperature);
+              this.platform.log.debug('Temperature:', data.reported.temperature);
+              break;
+            default:
+              platform.log.debug('Unknown command received:', Object.keys(data.reported)[0]);
+          }
+        }
+      }
+    });
+  }
+
+  // Handle requests to set the "Active" characteristic
+  setActive(value) {
+    this.platform.log.debug('Triggered SET Active:', value);
+    // Check state to prevent duplicate requests
+    if (this.on !== Boolean(value)) {
+      // Send to Dreo server via websocket
+      this.platform.webHelper.control(this.sn, {'poweron': Boolean(value)});
+    }
+  }
+
+  // Handle requests to get the current value of the "Active" characteristic
+  getActive() {
+    return this.on;
+  }
+
+  // Handle requests for Current Temperature
+  getCurrentTemperature() {
+    return this.temperature;
+  }
+
+  // Handle requests for Heating Threshold Temperature
+  setHeatingThresholdTemperature(value) {
+    this.platform.webHelper.control(this.sn, {'ecolevel': this.convertToFahrenheit(value)});
+  }
+
+  getHeatingThresholdTemperature() {
+    return this.targetTemperature;
+  }
+
+  // Turn child lock on/off
+  setLockPhysicalControls(value) {
+    this.platform.webHelper.control(this.sn, {'childlockon': Boolean(value)});
+  }
+
+  getLockPhysicalControls() {
+    return this.childLockOn;
+  }
+
+  convertToCelsius(temperatureFromDreo) {
+    // Dreo response is always Fahrenheit - convert to Celsius which is what HomeKit expects
+    return (temperatureFromDreo - 32) * 5 / 9;
+  }
+
+  convertToFahrenheit(temperatureFromHomeKit) {
+    // Dreo expects temperature in Fahrenheit for some reason
+    return (temperatureFromHomeKit * 9 / 5) + 32;
+  }
+}

--- a/src/accessories/HeaterAccessory.ts
+++ b/src/accessories/HeaterAccessory.ts
@@ -11,11 +11,12 @@ export class HeaterAccessory extends BaseAccessory {
   // Cached copy of latest device states
   private on: boolean;
   private mode: string;  // [hotair, eco, coolair]
-  private heatLevel: number;  // 1 - 3
+  private heatLevel: number;  // [1, 2, 3]
   private oscAngle: number;  // Oscillation angle: 0 = rotating, 60, 90, 120
   private temperature: number;
   private targetTemperature: number;
-  private tempUnit: number;  // Unit shown on physical disply: 1 = F, 2 = C
+  private heatActive: number;  // Heating element state {0: inactive, 1: idle, 2: heating}
+  private tempUnit: number;  // Unit shown on physical disply: {1: F, 2: C}
   private childLockOn: boolean;
 
   private modeMap = {
@@ -39,6 +40,7 @@ export class HeaterAccessory extends BaseAccessory {
     this.mode = this.modeMap[state.mode.state];
     this.heatLevel = state.htalevel.state;
     this.oscAngle = state.oscangle.state;
+    this.heatActive = state.ptcon.state;
     this.tempUnit = state.tempunit.state;
     this.childLockOn = state.childlockon.state;
 
@@ -54,7 +56,16 @@ export class HeaterAccessory extends BaseAccessory {
       .onSet(this.setActive.bind(this))
       .onGet(this.getActive.bind(this));
 
-    // Register handlers for the Current Temperature characteristic
+    // Register handlers for Current Heater-Cooler State
+    this.service.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState)
+      .onGet(this.getCurrentHeaterCoolerState.bind(this));
+
+    // Register handlers for Target Heater-Cooler State
+    this.service.getCharacteristic(this.platform.Characteristic.TargetHeaterCoolerState)
+      .onSet(this.setTargetHeaterCoolerState.bind(this))
+      .onGet(this.getTargetHeaterCoolerState.bind(this));
+
+    // Register handlers for Current Temperature characteristic
     this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
       .onGet(this.getCurrentTemperature.bind(this));
 
@@ -68,13 +79,10 @@ export class HeaterAccessory extends BaseAccessory {
         maxValue: this.convertToCelsius(ecoRange.endValue),
       });
 
-    // Check if child lock is supported
-    if (state.childlockon !== undefined) {
-      // Register handlers for Lock Physical Controls
-      this.service.getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
-        .onSet(this.setLockPhysicalControls.bind(this))
-        .onGet(this.getLockPhysicalControls.bind(this));
-    }
+    // Register handlers for Lock Physical Controls
+    this.service.getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
+      .onSet(this.setLockPhysicalControls.bind(this))
+      .onGet(this.getLockPhysicalControls.bind(this));
 
     // Update values from Dreo app
     platform.webHelper.addEventListener('message', message => {
@@ -86,34 +94,46 @@ export class HeaterAccessory extends BaseAccessory {
 
         // Check if we need to update fan state in homekit
         if (data.method === 'control-report' || data.method === 'control-reply' || data.method === 'report') {
-          switch(Object.keys(data.reported)[0]) {
-            case 'poweron':
-              this.on = data.reported.poweron;
-              this.service.getCharacteristic(this.platform.Characteristic.Active)
-                .updateValue(this.on);
-              this.platform.log.debug('Heater power:', data.reported.poweron);
-              break;
-            case 'mode':
-              this.mode = this.modeMap[data.reported.mode];
-              this.service.getCharacteristic(this.platform.Characteristic.TargetFanState)
-                .updateValue(this.mode);
-              this.platform.log.debug('Fan mode:', data.reported.mode);
-              break;
-            case 'childlockon':
-              this.childLockOn = Boolean(data.reported.childlockon);
-              this.service.getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
-                .updateValue(this.childLockOn);
-              this.platform.log.debug('Child lock:', data.reported.childlockon);
-              break;
-            case 'temperature':
-              this.temperature = this.convertToCelsius(data.reported.temperature);
-              this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
-                .updateValue(this.temperature);
-              this.platform.log.debug('Temperature:', data.reported.temperature);
-              break;
-            default:
-              platform.log.debug('Unknown command received:', Object.keys(data.reported)[0]);
-          }
+          Object.keys(data.reported).forEach(key => {
+            switch(key) {
+              case 'poweron':
+                this.on = data.reported.poweron;
+                this.service.getCharacteristic(this.platform.Characteristic.Active)
+                  .updateValue(this.on);
+                this.platform.log.debug('Heater power:', data.reported.poweron);
+                break;
+              case 'mode':
+                this.mode = this.modeMap[data.reported.mode];
+                this.service.getCharacteristic(this.platform.Characteristic.TargetFanState)
+                  .updateValue(this.mode);
+                this.platform.log.debug('Fan mode:', data.reported.mode);
+                break;
+              case 'childlockon':
+                this.childLockOn = data.reported.childlockon;
+                this.service.getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
+                  .updateValue(this.childLockOn);
+                this.platform.log.debug('Child lock:', data.reported.childlockon);
+                break;
+              case 'temperature':
+                this.temperature = this.convertToCelsius(data.reported.temperature);
+                this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+                  .updateValue(this.temperature);
+                this.platform.log.debug('Temperature:', data.reported.temperature);
+                break;
+              case 'ptcon':
+                if (this.mode !== 'coolair') {
+                  this.heatActive = data.reported.ptcon + this.on;
+                } else {
+                  this.heatActive = 3;
+                }
+                this.platform.log.debug('Heating active:', data.reported.ptcon);
+                this.service.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState)
+                  .updateValue(this.heatActive);
+                break;
+              default:
+                this.platform.log.debug('Unknown command received:', key);
+            }
+          });
         }
       }
     });
@@ -132,6 +152,20 @@ export class HeaterAccessory extends BaseAccessory {
   // Handle requests to get the current value of the "Active" characteristic
   getActive() {
     return this.on;
+  }
+
+  // Handle requests for Current Heater-Cooler State
+  getCurrentHeaterCoolerState() {
+    return this.heatActive;
+  }
+
+  // Handle requests for Target Heater-Cooler State
+  setTargetHeaterCoolerState(value) {
+    return;
+  }
+
+  getTargetHeaterCoolerState() {
+    return this.mode;
   }
 
   // Handle requests for Current Temperature
@@ -164,6 +198,6 @@ export class HeaterAccessory extends BaseAccessory {
 
   convertToFahrenheit(temperatureFromHomeKit) {
     // Dreo expects temperature in Fahrenheit for some reason
-    return (temperatureFromHomeKit * 9 / 5) + 32;
+    return Math.round((temperatureFromHomeKit * 9 / 5) + 32);
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -196,7 +196,7 @@ export class DreoPlatform implements DynamicPlatformPlugin {
           break;
 
         default:
-          this.log.error('Error, unknown device type:', device.productName);
+          this.log.error('Error, unknown device type:', device.productName, device.model);
       }
 
       if (!existingAccessory && modelPrefix) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -53,7 +53,7 @@ export class DreoPlatform implements DynamicPlatformPlugin {
    */
   async discoverDevices() {
     // Validate config values
-    if (this.config.options.email === undefined || this.config.options.password === undefined) {
+    if (!this.config.options || !this.config.options.email || !this.config.options.password) {
       this.log.error('error: Invalid email and/or password');
       return;
     }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -178,6 +178,7 @@ export class DreoPlatform implements DynamicPlatformPlugin {
         case 'DR-HSH':
         case 'WH':
           // Heater
+          //accessory.category = this.api.hap.Categories.AIR_HEATER;
           new HeaterAccessory(this, accessory, state);
           break;
         case 'DR-HAC':

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -172,18 +172,20 @@ export class DreoPlatform implements DynamicPlatformPlugin {
         case 'DR-HCF':
         case 'DR-HAP':
           // Tower Fan, Air Circulator, Ceiling Fan, Air Purifier
+          accessory.category = this.api.hap.Categories.FAN;
           new FanAccessory(this, accessory, state);
           break;
 
         case 'DR-HSH':
         case 'WH':
           // Heater
-          //accessory.category = this.api.hap.Categories.AIR_HEATER;
+          accessory.category = this.api.hap.Categories.AIR_HEATER;
           new HeaterAccessory(this, accessory, state);
           break;
         case 'DR-HAC':
           // Air Conditioner
           // new CoolerAccessory(this, accessory, state);
+          this.log.info('Air Conditioner not yet supported');
           modelPrefix = undefined;
           break;
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -2,6 +2,7 @@ import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, 
 
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
 import { FanAccessory } from './accessories/FanAccessory';
+import { HeaterAccessory } from './accessories/HeaterAccessory';
 import DreoAPI from './DreoAPI';
 
 /**
@@ -161,7 +162,7 @@ export class DreoPlatform implements DynamicPlatformPlugin {
       ];
 
       // Find the matching prefix
-      const modelPrefix = SUPPORTED_MODEL_PREFIXES.find(prefix => device.model.startsWith(prefix));
+      let modelPrefix = SUPPORTED_MODEL_PREFIXES.find(prefix => device.model.startsWith(prefix));
 
       // Determine device type based on the matched prefix
       switch (modelPrefix) {
@@ -177,24 +178,26 @@ export class DreoPlatform implements DynamicPlatformPlugin {
         case 'DR-HSH':
         case 'WH':
           // Heater
-          //new HeaterAccessory(this, accessory, state);
+          new HeaterAccessory(this, accessory, state);
           break;
         case 'DR-HAC':
           // Air Conditioner
           // new CoolerAccessory(this, accessory, state);
+          modelPrefix = undefined;
           break;
 
         case 'DR-HHM':
           // Humidifier
           this.log.info('Humidifier not yet supported');
+          modelPrefix = undefined;  // Unassign this so accessory isn't registered below
           break;
 
         default:
           this.log.error('Error, unknown device type:', device.productName);
       }
 
-      if (!existingAccessory) {
-        // Link the accessory to the platform
+      if (!existingAccessory && modelPrefix) {
+        // Link accessory to the platform if model is supported
         this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
       }
     }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -110,7 +110,7 @@ export class DreoPlatform implements DynamicPlatformPlugin {
     // Loop over the discovered devices and register each one if it has not already been registered
     for (const device of dreoDevices) {
       // Print device info:
-      this.log.debug('Control parameters: ', JSON.stringify(device.controlsConf.control, null, 2));
+      this.log.debug('Control config: ', JSON.stringify(device.controlsConf, null, 2));
 
       // Generate a unique id for the accessory this should be generated from
       // something globally unique, but constant, for example, the device serial

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,7 +1,7 @@
 import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, Service, Characteristic } from 'homebridge';
 
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
-import { FanAccessory } from './FanAccessory';
+import { FanAccessory } from './accessories/FanAccessory';
 import DreoAPI from './DreoAPI';
 
 /**


### PR DESCRIPTION
Currently a work-in-progress. The main hurdle I'm running into right now is the limited amount of control characteristics for heaters in HomeKit: https://developers.homebridge.io/#/service/HeaterCooler

I could implement something similar to the following:
Heat only thermostat accessory: Dreo 'eco' mode (set target heating temp)
Separate switch for fan only mode
Light/fan accessory to control static speed heat mode
Light/fan accessory or group of switches to control oscillation angle

Another option, implement everything into a single heater/cooler thermostat:
Off: off
Heat: Dreo 'eco' mode (set target heating temp)
Cool: fan only
Auto: static heat mode (1-3 in Dreo app)
Light/fan accessory to control oscillation angle

Would love to hear user feedback/suggestions if you have any ideas.