### PR TITLE
[BugFix] Fix heaters which can't swing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,3 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
-
-*.iml
-*DoNotCommit*

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
+
+*.iml
+*DoNotCommit*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Dreo",
   "name": "homebridge-dreo",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Homebridge Plugin for Dreo Smart Devices",
   "homepage": "https://github.com/zyonse/homebridge-dreo",
   "license": "Apache-2.0",

--- a/src/accessories/HeaterAccessory.ts
+++ b/src/accessories/HeaterAccessory.ts
@@ -38,8 +38,8 @@ export class HeaterAccessory extends BaseAccessory {
   };
 
   minTemp: number;
-  canSetAngle: boolean;
   canSwing: boolean;
+  canSetAngle: boolean;
 
   constructor(
     platform: DreoPlatform,
@@ -72,12 +72,13 @@ export class HeaterAccessory extends BaseAccessory {
         this.oscAngle = this.oscMap[state.oscangle.state];
       }
     } else if (state.oscon) {
+      // Fan only supports on/off oscillation toggle
       this.canSetAngle = false;
       this.canSwing = true;
       this.swing = state.oscon.state;
       this.oscAngle = 0;
     } else {
-      // Fan only supports on/off oscillation toggle
+      // Fan does not support oscillation
       this.canSwing = false;
       this.canSetAngle = false;
       this.swing = false;
@@ -176,8 +177,8 @@ export class HeaterAccessory extends BaseAccessory {
     // Swing mode
     if (this.canSwing) {
       this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
-          .onSet(this.setSwingMode.bind(this))
-          .onGet(this.getSwingMode.bind(this));
+        .onSet(this.setSwingMode.bind(this))
+        .onGet(this.getSwingMode.bind(this));
     }
 
 

--- a/src/accessories/HeaterAccessory.ts
+++ b/src/accessories/HeaterAccessory.ts
@@ -39,6 +39,7 @@ export class HeaterAccessory extends BaseAccessory {
 
   minTemp: number;
   canSetAngle: boolean;
+  canSwing: boolean;
 
   constructor(
     platform: DreoPlatform,
@@ -62,6 +63,7 @@ export class HeaterAccessory extends BaseAccessory {
     if (state.oscangle) {
       // Fan supports setting specific oscillation angles
       this.canSetAngle = true;
+      this.canSwing = true;
       if (state.oscangle.state === 0) {
         this.swing = true;
         this.oscAngle = 0;
@@ -69,10 +71,16 @@ export class HeaterAccessory extends BaseAccessory {
         this.swing = false;
         this.oscAngle = this.oscMap[state.oscangle.state];
       }
+    } else if (state.oscon) {
+      this.canSetAngle = false;
+      this.canSwing = true;
+      this.swing = state.oscon.state;
+      this.oscAngle = 0;
     } else {
       // Fan only supports on/off oscillation toggle
+      this.canSwing = false;
       this.canSetAngle = false;
-      this.swing = state.oscon.state;
+      this.swing = false;
       this.oscAngle = 0;
     }
 
@@ -166,9 +174,11 @@ export class HeaterAccessory extends BaseAccessory {
       .onGet(this.getTemperatureDisplayUnits.bind(this));
 
     // Swing mode
-    this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
-      .onSet(this.setSwingMode.bind(this))
-      .onGet(this.getSwingMode.bind(this));
+    if (this.canSwing) {
+      this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
+          .onSet(this.setSwingMode.bind(this))
+          .onGet(this.getSwingMode.bind(this));
+    }
 
 
     // Update values from Dreo app


### PR DESCRIPTION
WH517S can't swing but we were looking for its swinging state. Causing whole plugin to fail.

I have verified the fix on my local homebridge instance