### PR TITLE
Fixes crash: WebSocket is closed before the connection is established

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "lint": "eslint src/**.ts --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",
-    "prepublishOnly": "npm run lint && npm run build"
+    "prepublishOnly": "npm run lint && npm run build",
+    "postinstall": "patch-package"
   },
   "keywords": [
     "homebridge-plugin",
@@ -41,6 +42,7 @@
   "dependencies": {
     "axios": "^1.3.5",
     "crypto-js": "^4.1.1",
+    "patch-package": "^8.0.1",
     "reconnecting-websocket": "^4.4.0",
     "ws": "^8.13.0"
   },

--- a/patches/reconnecting-websocket+4.4.0.patch
+++ b/patches/reconnecting-websocket+4.4.0.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/reconnecting-websocket/reconnecting-websocket.ts b/node_modules/reconnecting-websocket/reconnecting-websocket.ts
+index c383282..9717dc9 100644
+--- a/node_modules/reconnecting-websocket/reconnecting-websocket.ts
++++ b/node_modules/reconnecting-websocket/reconnecting-websocket.ts
+@@ -401,7 +401,17 @@ export default class ReconnectingWebSocket {
+         }
+         this._removeListeners();
+         try {
+-            this._ws.close(code, reason);
++            if (this._ws.readyState === this.CLOSING || this._ws.readyState === this.CLOSED) {
++                return;
++            }
++
++            const ws = this._ws as any;
++            if (this._ws.readyState === this.CONNECTING && typeof ws.terminate === 'function') {
++                ws.terminate();
++            } else {
++                this._ws.close(code, reason);
++            }
++
+             this._handleClose(new Events.CloseEvent(code, reason, this));
+         } catch (error) {
+             // ignore


### PR DESCRIPTION
About once every day or so, `homebridge-dreo` crashes for me with the following error:

```
/homebridge/node_modules/homebridge-dreo/node_modules/ws/lib/websocket.js:300
      abortHandshake(this, this._req, msg);
      ^
Error: WebSocket was closed before the connection was established
    at WebSocket.close (/homebridge/node_modules/homebridge-dreo/node_modules/ws/lib/websocket.js:300:7)
    at ReconnectingWebSocket._disconnect (/homebridge/node_modules/homebridge-dreo/node_modules/reconnecting-websocket/dist/reconnecting-websocket-cjs.js:539:22)
    at ReconnectingWebSocket._handleError (/homebridge/node_modules/homebridge-dreo/node_modules/reconnecting-websocket/dist/reconnecting-websocket-cjs.js:180:19)
    at ReconnectingWebSocket._handleTimeout (/homebridge/node_modules/homebridge-dreo/node_modules/reconnecting-websocket/dist/reconnecting-websocket-cjs.js:529:14)
    at Timeout.<anonymous> (/homebridge/node_modules/homebridge-dreo/node_modules/reconnecting-websocket/dist/reconnecting-websocket-cjs.js:524:75)
    at listOnTimeout (node:internal/timers:605:17)
    at processTimers (node:internal/timers:541:7)
```

Digging in, this is due to a 13-year-old [bug in reconnecting-websocket](https://github.com/joewalnes/reconnecting-websocket/issues/6).

The best fix is probably to rewrite `DreoAPI.ts` to avoid use of `ReconnectingWebSocket` altogether, which hasn't been updated in a decade.

In the meantime, this PR applies a small patch to `reconnecting-websocket.ts` during build/install to correctly avoid calling `Websocket.close()` if it's in the wrong state.

This should also fix the crash loop described here: https://github.com/zyonse/homebridge-dreo/issues/82

Thanks for considering and let me know if you have any questions or change requests!