### PR TITLE
WebSocket Rewrite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,13 +3,33 @@ name: Build and Lint
 on: [push, pull_request]
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      # `npm ci` installs exactly what package-lock.json pins, and fails if the lockfile
+      # is out of sync with package.json
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
   build:
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,9 @@
 # Ignore source code
 src
 
+# Tests are for development only
+test
+
 # ------------- Defaults ------------- #
 
 # gitHub actions

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "axios": "^1.3.5",
         "crypto-js": "^4.1.1",
-        "reconnecting-websocket": "^4.4.0",
         "ws": "^8.13.0"
       },
       "devDependencies": {
@@ -2542,11 +2541,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/reconnecting-websocket": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
-      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
@@ -5041,11 +5035,6 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
-    },
-    "reconnecting-websocket": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
-      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
     },
     "regexp.prototype.flags": {
       "version": "1.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       },
       "engines": {
         "homebridge": "^1.3.5 || ^2.0.0",
-        "node": ">=14.18.1"
+        "node": ">=20.7.0"
       },
       "funding": {
         "type": "paypal",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://paypal.me/zyonse"
   },
   "engines": {
-    "node": ">=14.18.1",
+    "node": ">=20.7.0",
     "homebridge": "^1.3.5 || ^2.0.0"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "lint": "eslint src/**.ts --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",
-    "prepublishOnly": "npm run lint && npm run build"
+    "prepublishOnly": "npm run lint && npm run build && npm test",
+    "test": "npm run build && node --test \"test/**/*.test.js\""
   },
   "keywords": [
     "homebridge-plugin",
@@ -41,7 +42,6 @@
   "dependencies": {
     "axios": "^1.3.5",
     "crypto-js": "^4.1.1",
-    "reconnecting-websocket": "^4.4.0",
     "ws": "^8.13.0"
   },
   "devDependencies": {

--- a/src/DreoAPI.ts
+++ b/src/DreoAPI.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import MD5 from 'crypto-js/md5';
-import ReconnectingWebSocket from 'reconnecting-websocket';
-import WebSocket from 'ws';
+import DreoWebSocket from './DreoWebSocket';
 import type { DreoPlatform } from './platform';
 import type { Logger } from 'homebridge';
 
@@ -14,7 +13,7 @@ export default class DreoAPI {
   private readonly password: string;
   private readonly log: Logger;
   private access_token: string;
-  private ws: WebSocket;
+  private ws!: DreoWebSocket;
   public server: string;
 
   constructor(platform: DreoPlatform) {
@@ -122,27 +121,22 @@ export default class DreoAPI {
   // Open websocket for outgoing fan commands, websocket will auto-reconnect if a connection error occurs
   // Websocket is also used to monitor incoming state changes from hardware controls
   public async startWebSocket() {
-    // open websocket
-    const url = 'wss://wsb-'+this.server+'.dreo-tech.com/websocket?accessToken='+this.access_token+'&timestamp='+Date.now();
-    this.ws = new ReconnectingWebSocket(
-      url,
-      [],
-      {WebSocket: WebSocket});
+    this.ws = new DreoWebSocket(async (attempt) => {
+      // The URL is rebuilt for every attempt: the timestamp must be current, and the access token
+      // may have expired while we were disconnected. Re-authenticate once retries start failing.
+      if (attempt >= 2) {
+        this.log.debug('Refreshing access token before WebSocket reconnect');
+        await this.authenticate();
+      }
+      return 'wss://wsb-'+this.server+'.dreo-tech.com/websocket?accessToken='+this.access_token+'&timestamp='+Date.now();
+    }, this.log);
 
-    this.ws.addEventListener('error', error => {
-      this.log.debug('WebSocket', error);
-    });
+    this.ws.start();
+  }
 
-    this.ws.addEventListener('open', () => {
-      this.log.debug('WebSocket Opened');
-    });
-
-    this.ws.addEventListener('close', () => {
-      this.log.debug('WebSocket Closed');
-    });
-
-    // Keep connection open by sending empty packet every 15 seconds
-    setInterval(() => this.ws.send('2'), 15000);
+  // Close the websocket and stop reconnecting (called on Homebridge shutdown)
+  public stopWebSocket() {
+    this.ws?.stop();
   }
 
   // Allow devices to add event listeners to the WebSocket

--- a/src/DreoWebSocket.ts
+++ b/src/DreoWebSocket.ts
@@ -1,0 +1,229 @@
+import WebSocket from 'ws';
+import type { Logger } from 'homebridge';
+
+// Reconnect backoff bounds
+const MIN_RECONNECT_DELAY = 1000;
+const MAX_RECONNECT_DELAY = 60000;
+// Dreo's servers drop idle connections, so send an app-level keepalive on this interval
+const KEEPALIVE_INTERVAL = 15000;
+// How long to wait for a pong before assuming the connection is half-open
+const PONG_TIMEOUT = 10000;
+// How long to wait for the handshake to complete before giving up and retrying
+const CONNECT_TIMEOUT = 10000;
+
+type Listener = (event) => void;
+
+// Timings are overridable so tests can exercise reconnect/keepalive behaviour quickly
+export interface DreoWebSocketOptions {
+  keepaliveInterval?: number;
+  pongTimeout?: number;
+  connectTimeout?: number;
+  minReconnectDelay?: number;
+  maxReconnectDelay?: number;
+}
+
+/**
+ * Auto-reconnecting WebSocket client for the Dreo cloud.
+ *
+ * Listeners are held here rather than on the underlying socket, so registrations made once at
+ * startup survive every reconnect. The socket itself is disposable; this wrapper is not.
+ */
+export default class DreoWebSocket {
+  private ws?: WebSocket;
+  private readonly listeners = new Map<string, Set<Listener>>();
+  private keepaliveTimer?: NodeJS.Timeout;
+  private reconnectTimer?: NodeJS.Timeout;
+  private pongTimer?: NodeJS.Timeout;
+  private connectTimer?: NodeJS.Timeout;
+  private attempt = 0;
+  private stopped = false;
+  // Only enforce the pong timeout if the server has actually answered a ping at least once
+  private pongSupported = false;
+  private readonly keepaliveInterval: number;
+  private readonly pongTimeout: number;
+  private readonly connectTimeout: number;
+  private readonly minReconnectDelay: number;
+  private readonly maxReconnectDelay: number;
+
+  // getUrl is called before every connection attempt so the token and timestamp are always current
+  constructor(
+    private readonly getUrl: (attempt: number) => Promise<string>,
+    private readonly log: Logger,
+    options: DreoWebSocketOptions = {},
+  ) {
+    this.keepaliveInterval = options.keepaliveInterval ?? KEEPALIVE_INTERVAL;
+    this.pongTimeout = options.pongTimeout ?? PONG_TIMEOUT;
+    this.connectTimeout = options.connectTimeout ?? CONNECT_TIMEOUT;
+    this.minReconnectDelay = options.minReconnectDelay ?? MIN_RECONNECT_DELAY;
+    this.maxReconnectDelay = options.maxReconnectDelay ?? MAX_RECONNECT_DELAY;
+  }
+
+  public start() {
+    this.stopped = false;
+    this.connect();
+  }
+
+  // Stop reconnecting and tear down the current connection (called on Homebridge shutdown)
+  public stop() {
+    this.stopped = true;
+    this.clearTimer(this.reconnectTimer);
+    this.reconnectTimer = undefined;
+    this.clearTimer(this.connectTimer);
+    this.connectTimer = undefined;
+    this.stopKeepalive();
+    this.ws?.close();
+    this.ws = undefined;
+  }
+
+  // Register a listener that persists across reconnects
+  public addEventListener(event: string, listener: Listener) {
+    const existing = this.listeners.get(event);
+    if (existing) {
+      existing.add(listener);
+    } else {
+      this.listeners.set(event, new Set([listener]));
+    }
+  }
+
+  public send(data: string) {
+    if (this.ws?.readyState !== WebSocket.OPEN) {
+      // Matches the old behaviour of dropping sends while disconnected, but says so out loud
+      this.log.debug('WebSocket not open, dropping message');
+      return;
+    }
+    this.ws.send(data);
+  }
+
+  private async connect() {
+    if (this.stopped) {
+      return;
+    }
+
+    let url: string;
+    try {
+      url = await this.getUrl(this.attempt);
+    } catch (error) {
+      this.log.debug('Could not build WebSocket URL:', error);
+      this.scheduleReconnect();
+      return;
+    }
+
+    const ws = new WebSocket(url);
+    this.ws = ws;
+
+    // A hung TCP handshake would otherwise sit in CONNECTING until the OS gives up (~75s).
+    // terminate() aborts it; the 'error' handler below catches the resulting async emit.
+    this.connectTimer = setTimeout(() => {
+      this.connectTimer = undefined;
+      this.log.debug('WebSocket connection timed out');
+      ws.terminate();
+    }, this.connectTimeout);
+
+    // Attached for the socket's entire lifetime. `ws` emits 'error' asynchronously (process.nextTick)
+    // when a handshake is aborted; an unhandled 'error' event would take down the Homebridge process.
+    ws.on('error', (error) => {
+      this.log.debug('WebSocket error:', error.message);
+      this.emit('error', error);
+    });
+
+    ws.on('open', () => {
+      this.attempt = 0;
+      this.clearTimer(this.connectTimer);
+      this.connectTimer = undefined;
+      this.log.debug('WebSocket Opened');
+      this.startKeepalive();
+      this.emit('open', {});
+    });
+
+    ws.on('message', (raw) => {
+      // Accessories expect a MessageEvent-like object with a string `data` field
+      const data = Array.isArray(raw) ? Buffer.concat(raw).toString() : raw.toString();
+      this.emit('message', {data: data});
+    });
+
+    ws.on('pong', () => {
+      this.pongSupported = true;
+      this.clearTimer(this.pongTimer);
+      this.pongTimer = undefined;
+    });
+
+    ws.on('close', (code, reason) => {
+      this.clearTimer(this.connectTimer);
+      this.connectTimer = undefined;
+      this.stopKeepalive();
+      this.log.debug('WebSocket Closed');
+      this.emit('close', {code: code, reason: reason.toString()});
+      // Only the active socket may trigger a reconnect; a stale one closing must not
+      if (this.ws === ws) {
+        this.scheduleReconnect();
+      }
+    });
+  }
+
+  private scheduleReconnect() {
+    if (this.stopped || this.reconnectTimer) {
+      return;
+    }
+
+    // Exponential backoff, half-jittered so every plugin instance doesn't retry in lockstep
+    const backoff = Math.min(this.maxReconnectDelay, this.minReconnectDelay * Math.pow(2, this.attempt));
+    const delay = backoff / 2 + Math.random() * (backoff / 2);
+    this.attempt++;
+
+    this.log.debug('Reconnecting to WebSocket in %dms', Math.round(delay));
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      this.connect();
+    }, delay);
+  }
+
+  private startKeepalive() {
+    this.stopKeepalive();
+    this.keepaliveTimer = setInterval(() => {
+      if (this.ws?.readyState !== WebSocket.OPEN) {
+        return;
+      }
+      this.ws.send('2');
+      this.ws.ping();
+
+      // A half-open TCP connection accepts writes forever, so wait for a pong to prove it is alive.
+      // Skipped until we know the server answers pings at all, otherwise we would kill a healthy socket.
+      if (this.pongSupported && !this.pongTimer) {
+        this.pongTimer = setTimeout(() => {
+          this.pongTimer = undefined;
+          this.log.debug('WebSocket keepalive timed out, terminating');
+          this.ws?.terminate();
+        }, this.pongTimeout);
+      }
+    }, this.keepaliveInterval);
+  }
+
+  private stopKeepalive() {
+    this.clearTimer(this.keepaliveTimer);
+    this.keepaliveTimer = undefined;
+    this.clearTimer(this.pongTimer);
+    this.pongTimer = undefined;
+  }
+
+  private clearTimer(timer?: NodeJS.Timeout) {
+    if (timer) {
+      clearTimeout(timer);
+      clearInterval(timer);
+    }
+  }
+
+  private emit(event: string, payload) {
+    const listeners = this.listeners.get(event);
+    if (!listeners) {
+      return;
+    }
+    listeners.forEach((listener) => {
+      // One misbehaving accessory must not stop the others from receiving updates
+      try {
+        listener(payload);
+      } catch (error) {
+        this.log.error('Error in WebSocket %s listener:', event, error);
+      }
+    });
+  }
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -35,6 +35,11 @@ export class DreoPlatform implements DynamicPlatformPlugin {
       // Run the method to discover / register your devices as accessories
       this.discoverDevices();
     });
+
+    // Close the websocket cleanly so its timers don't keep the process alive
+    this.api.on('shutdown', () => {
+      this.webHelper.stopWebSocket();
+    });
   }
 
   /**

--- a/test/DreoWebSocket.test.js
+++ b/test/DreoWebSocket.test.js
@@ -1,0 +1,187 @@
+// Regression tests for the Dreo websocket client, driven against a simulated Dreo cloud.
+// Run with: npm test
+const test = require('node:test');
+const assert = require('node:assert');
+const DreoWebSocket = require('../dist/DreoWebSocket').default;
+const { MockDreoServer, BlackholeServer } = require('./helpers/mock-dreo-server');
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const silentLog = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+// Fast timings so the suite runs in seconds rather than minutes
+const fast = {
+  keepaliveInterval: 100,
+  pongTimeout: 150,
+  connectTimeout: 200,
+  minReconnectDelay: 50,
+  maxReconnectDelay: 200,
+};
+
+// Waits for a condition instead of sleeping a fixed time, so tests aren't flaky under load
+async function waitFor(predicate, timeout = 4000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    await sleep(20);
+  }
+  return false;
+}
+
+test('connects and delivers messages to registered listeners', async (t) => {
+  const server = await new MockDreoServer().start();
+  const client = new DreoWebSocket(async () => server.url, silentLog, fast);
+  t.after(async () => {
+    client.stop();
+    await server.stop();
+  });
+
+  const messages = [];
+  client.addEventListener('message', (e) => messages.push(JSON.parse(e.data)));
+  client.start();
+
+  assert.ok(await waitFor(() => server.connections === 1), 'client should connect');
+  server.broadcast({ devicesn: 'SN1', method: 'report', state: { poweron: true } });
+
+  assert.ok(await waitFor(() => messages.length === 1), 'listener should receive the report');
+  assert.strictEqual(messages[0].method, 'report');
+});
+
+test('control commands round-trip and the reply reaches the listener', async (t) => {
+  const server = await new MockDreoServer().start();
+  const client = new DreoWebSocket(async () => server.url, silentLog, fast);
+  t.after(async () => {
+    client.stop();
+    await server.stop();
+  });
+
+  const replies = [];
+  client.addEventListener('message', (e) => replies.push(JSON.parse(e.data)));
+  client.start();
+  await waitFor(() => server.connections === 1);
+
+  client.send(JSON.stringify({ deviceSn: 'SN1', method: 'control', params: { poweron: true } }));
+
+  assert.ok(await waitFor(() => replies.length === 1), 'should receive control-reply');
+  assert.strictEqual(replies[0].method, 'control-reply');
+  assert.deepStrictEqual(replies[0].reported, { poweron: true });
+  assert.deepStrictEqual(server.controls[0].params, { poweron: true });
+});
+
+// accessories register once at startup and must keep receiving updates forever after.
+test('a listener registered once survives a server-side drop and reconnect', async (t) => {
+  const server = await new MockDreoServer().start();
+  const client = new DreoWebSocket(async () => server.url, silentLog, fast);
+  t.after(async () => {
+    client.stop();
+    await server.stop();
+  });
+
+  const messages = [];
+  client.addEventListener('message', (e) => messages.push(JSON.parse(e.data)));
+  client.start();
+  await waitFor(() => server.connections === 1);
+
+  server.dropAll();
+  assert.ok(await waitFor(() => server.connections === 2), 'client should reconnect after a drop');
+
+  server.broadcast({ devicesn: 'SN1', method: 'report', state: { poweron: false } });
+  assert.ok(await waitFor(() => messages.length === 1), 'listener must still fire after reconnect');
+});
+
+// aborting a handshake makes ws emit 'error' on process.nextTick. With no listener attached
+// that is an unhandled 'error' event, which takes down the whole Homebridge process.
+test('an aborted handshake is reported, not fatal', async (t) => {
+  const blackhole = await new BlackholeServer().start();
+  const client = new DreoWebSocket(async () => blackhole.url, silentLog, fast);
+  t.after(async () => {
+    client.stop();
+    await blackhole.stop();
+  });
+
+  const errors = [];
+  client.addEventListener('error', (e) => errors.push(e.message));
+  client.start();
+
+  // If the deferred emit were unhandled, the test process would die here instead of asserting
+  assert.ok(
+    await waitFor(() => errors.some((m) => /closed before the connection was established/.test(m))),
+    'the abort should surface as a handled error event',
+  );
+  assert.ok(await waitFor(() => errors.length >= 2), 'client should keep retrying after an abort');
+});
+
+test('the URL is rebuilt for every connection attempt', async (t) => {
+  const blackhole = await new BlackholeServer().start();
+  const attempts = [];
+  const client = new DreoWebSocket(async (attempt) => {
+    attempts.push(attempt);
+    return `${blackhole.url}/?token=t${attempt}&timestamp=${Date.now()}`;
+  }, silentLog, fast);
+  t.after(async () => {
+    client.stop();
+    await blackhole.stop();
+  });
+
+  client.start();
+  assert.ok(await waitFor(() => attempts.length >= 3), 'should keep re-deriving the URL');
+  assert.deepStrictEqual(attempts.slice(0, 3), [0, 1, 2], 'attempt counter should advance');
+});
+
+test('sends the keepalive while connected', async (t) => {
+  const server = await new MockDreoServer().start();
+  const client = new DreoWebSocket(async () => server.url, silentLog, fast);
+  t.after(async () => {
+    client.stop();
+    await server.stop();
+  });
+
+  client.start();
+  assert.ok(await waitFor(() => server.keepalives >= 2), 'keepalives should be sent on an interval');
+});
+
+// A half-open connection accepts writes forever. Without a pong check the plugin looks
+// connected while silently receiving nothing.
+test('recovers from a half-open connection that stops answering pings', async (t) => {
+  const server = await new MockDreoServer().start();
+  const client = new DreoWebSocket(async () => server.url, silentLog, fast);
+  t.after(async () => {
+    client.stop();
+    await server.stop();
+  });
+
+  client.start();
+  // Let at least one ping/pong through first, so the client learns the server answers pings
+  await waitFor(() => server.keepalives >= 1);
+  server.freeze();
+
+  assert.ok(await waitFor(() => server.connections >= 2, 6000), 'should terminate and reconnect');
+});
+
+test('send() while disconnected is dropped, not thrown', async (t) => {
+  const server = await new MockDreoServer().start();
+  const client = new DreoWebSocket(async () => server.url, silentLog, fast);
+  t.after(async () => {
+    client.stop();
+    await server.stop();
+  });
+
+  // Never started, so there is no socket at all
+  assert.doesNotThrow(() => client.send('{"method":"control"}'));
+});
+
+test('stop() ends reconnection', async (t) => {
+  const server = await new MockDreoServer().start();
+  const client = new DreoWebSocket(async () => server.url, silentLog, fast);
+  t.after(async () => await server.stop());
+
+  client.start();
+  await waitFor(() => server.connections === 1);
+
+  client.stop();
+  server.dropAll();
+  await sleep(500);
+
+  assert.strictEqual(server.connections, 1, 'no reconnect should happen after stop()');
+});

--- a/test/helpers/mock-dreo-server.js
+++ b/test/helpers/mock-dreo-server.js
@@ -1,0 +1,105 @@
+// Software-in-the-loop stand-in for the Dreo cloud.
+//
+// Speaks enough of the real protocol for the websocket client to be exercised without
+// credentials or hardware: it accepts the token query string, answers pings, records the
+// '2' keepalive, and replies to control commands the way the real server does:
+//
+//   -> {"deviceSn":"...","method":"control","params":{"poweron":true}}
+//   <- {"devicesn":"...","method":"control-reply","reported":{"poweron":true}}
+//
+// It can also misbehave on demand: drop connections server-side, or freeze a socket to
+// simulate a half-open TCP connection that accepts writes but never answers.
+const http = require('http');
+const { WebSocketServer } = require('ws');
+
+class MockDreoServer {
+  constructor() {
+    this.connections = 0;
+    this.keepalives = 0;
+    this.controls = [];
+    this.tokens = [];
+  }
+
+  async start() {
+    this.wss = new WebSocketServer({ port: 0 });
+    await new Promise((resolve) => this.wss.once('listening', resolve));
+    this.port = this.wss.address().port;
+
+    this.wss.on('connection', (socket, req) => {
+      this.connections++;
+      this.tokens.push(new URL(req.url, 'http://x').searchParams.get('accessToken'));
+
+      socket.on('message', (raw) => {
+        const text = raw.toString();
+        if (text === '2') {
+          this.keepalives++;
+          return;
+        }
+        const msg = JSON.parse(text);
+        if (msg.method === 'control') {
+          this.controls.push(msg);
+          socket.send(JSON.stringify({
+            devicesn: msg.deviceSn,
+            method: 'control-reply',
+            reported: msg.params,
+          }));
+        }
+      });
+    });
+    return this;
+  }
+
+  get url() {
+    return `ws://127.0.0.1:${this.port}`;
+  }
+
+  // Push an unsolicited state report, as the real server does on a hardware control
+  broadcast(payload) {
+    this.wss.clients.forEach((c) => c.send(JSON.stringify(payload)));
+  }
+
+  // Hard server-side disconnect
+  dropAll() {
+    this.wss.clients.forEach((c) => c.terminate());
+  }
+
+  // Stop reading from the sockets: writes still "succeed", but nothing ever comes back
+  // and pings go unanswered. This is what a half-open connection looks like.
+  freeze() {
+    this.wss.clients.forEach((c) => c._socket.pause());
+  }
+
+  async stop() {
+    this.wss.clients.forEach((c) => c.terminate());
+    await new Promise((resolve) => this.wss.close(resolve));
+  }
+}
+
+/**
+ * Accepts the TCP connection and the HTTP upgrade request, then never replies.
+ * The client is left in CONNECTING until it gives up — the exact state in which
+ * calling close()/terminate() triggers ws's abortHandshake() and its deferred
+ * 'error' emit.
+ */
+class BlackholeServer {
+  async start() {
+    this.sockets = [];
+    this.server = http.createServer();
+    this.server.on('upgrade', (req, socket) => this.sockets.push(socket)); // deliberately no response
+    this.server.listen(0);
+    await new Promise((resolve) => this.server.once('listening', resolve));
+    this.port = this.server.address().port;
+    return this;
+  }
+
+  get url() {
+    return `ws://127.0.0.1:${this.port}`;
+  }
+
+  async stop() {
+    this.sockets.forEach((s) => s.destroy());
+    await new Promise((resolve) => this.server.close(resolve));
+  }
+}
+
+module.exports = { MockDreoServer, BlackholeServer };


### PR DESCRIPTION
- Added GitHub CI job with regression test suite running the real websocket client against a simulated Dreo cloud.
- Fixed crash "WebSocket was closed before the connection was established"
- Fixed reconnects failing permanently after the access token expired.
- Fixed 15s keepalive timer that kept running after Homebridge shutdown.
- Fixed stalled TCP handshake.
- Fixed undetected half-open connections where the plugin appeared connected while silently receiving no device updates. Ping/pong monitoring now detects this and reconnects.

Special thanks to @mpatfield for diagnosing this issue in #120 

Closes #82