### PR TITLE
Add DR-HTF017S oscillation fallback and optional fan controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Homebridge plugin for Dreo brand smart devices. [Dreo Fans on Amazon](https://ww
 * DR-HTF005S
 * DR-HTF007S
 * DR-HTF011S
+* DR-HTF017S
 
 #### Heaters
 
@@ -64,8 +65,16 @@ Please open an issue if you have another model that works or doesn't work. If yo
 * **Fan Speed:** Fan speed is displayed as a percentage value with steps that are equivalent to those of the Dreo app. (for example, a fan with speeds 1-6 will have steps at 17%, 33%, 50% etc)
 
 * **Oscillate:** Toggles fan oscillation
+* **Natural and Sleep Modes (optional):** Adds separate, clearly named switches for fan modes that HomeKit does not represent natively.
+* **Fan Preferences (optional):** Adds supported display and panel-sound controls as separate, clearly named switches.
 * **Temperature Sensor:** Displays current temperature sensor reading. (for supported devices, check your devices capabilities) Because the Dreo fan temperature sensors are not entirely accurate, you can also set a specific temperature offset for your devices.
 * **Child Lock:** Lock physical fan controls
+
+Additional fan controls are disabled by default, leaving the standard fan tile,
+native oscillation control, and optional temperature sensor. Enable **Expose
+Natural and Sleep Modes** or **Expose Fan Preferences** in the plugin settings
+only when those additional controls are wanted. Their names include the Dreo
+device name so controls from multiple fans remain distinguishable.
 
 ### Heaters
 
@@ -123,6 +132,8 @@ Provide your Dreo app login credentials
     },
     "hideTemperatureSensor": false,
     "temperatureOffset": 0,
+    "exposeFanModeSwitches": false,
+    "exposeFanPreferences": false,
     "name": "Dreo Platform",
     "platform": "DreoPlatform"
   }

--- a/config.schema.json
+++ b/config.schema.json
@@ -49,6 +49,18 @@
         },
         "default": 0,
         "description": "Subtract (or add) a set amount from the temperature reading (use negative numbers to subtract). This setting only applies to fans."
+      },
+      "exposeFanModeSwitches": {
+        "title": "Expose Natural and Sleep Modes",
+        "type": "boolean",
+        "default": false,
+        "description": "Expose Natural Breeze and Sleep Mode as additional fan switches. Native Normal and Auto modes remain available through the fan control."
+      },
+      "exposeFanPreferences": {
+        "title": "Expose Fan Preferences",
+        "type": "boolean",
+        "default": false,
+        "description": "Expose supported display and panel-sound preferences as additional switches."
       }
     }
   },
@@ -67,6 +79,16 @@
       "items": [
         "hideTemperatureSensor",
         "temperatureOffset"
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Additional Fan Controls",
+      "expandable": true,
+      "expanded": false,
+      "items": [
+        "exposeFanModeSwitches",
+        "exposeFanPreferences"
       ]
     }
   ]

--- a/src/accessories/FanAccessory.ts
+++ b/src/accessories/FanAccessory.ts
@@ -1,14 +1,15 @@
-import { Service, PlatformAccessory } from 'homebridge';
+import { CharacteristicValue, Service, PlatformAccessory } from 'homebridge';
 import { DreoPlatform } from '../platform';
 import { BaseAccessory } from './BaseAccessory';
-
-// Known oscillation state keys, in priority order. Add new keys here if Dreo
-// introduces additional oscillation commands on future devices.
-const OSCILLATION_KEYS = ['shakehorizon', 'hoscon', 'oscmode'] as const;
+import {
+  FAN_MODE_SWITCHES,
+  getModeCommand,
+  getOscillationCommand,
+  getStateValue,
+} from './FanCapabilities';
 
 // Fallback maxSpeed for devices whose Dreo API returns an incomplete controlsConf
-// (e.g. { template: 'DR-HPF002S' } with no control array). swingCmd is not needed
-// here — it is auto-detected from whichever oscillation key is present in device state.
+// (e.g. { template: 'DR-HPF002S' } with no control array).
 //
 // Future enhancement: resolve the template model name returned in controlsConf against
 // the Dreo API to fetch the real maxSpeed, eliminating the need for this map entirely.
@@ -31,6 +32,9 @@ export class FanAccessory extends BaseAccessory {
   private service: Service;
   private temperatureService?: Service;
   private lightService?: Service;
+  private displayAutoOffService?: Service;
+  private panelSoundService?: Service;
+  private readonly modeServices = new Map<number, Service>();
 
   // Cached copy of latest fan states
   private currState = {
@@ -39,12 +43,16 @@ export class FanAccessory extends BaseAccessory {
     speed: 1,
     swing: false,
     swingCMD: 'none', // Command used to control oscillation (shakehorizon, hoscon, oscmode)
+    mode: 1,
+    modeCMD: 'none', // Command used to control mode (windtype, mode)
     autoMode: false,
     lockPhysicalControls: false,
     maxSpeed: 1,
     temperature: 0,
     lightOn: false,
     brightness: 100,
+    ledAlwaysOn: false,
+    panelSound: false,
   };
 
   constructor(
@@ -114,12 +122,10 @@ export class FanAccessory extends BaseAccessory {
 
     // Check whether fan supports oscillation. First try the API controlsConf, then
     // auto-detect from whichever oscillation key is present in the device state.
-    this.currState.swingCMD =
-      accessory.context.device?.controlsConf?.control?.find(
-        (params) => params.type === 'Oscillation',
-      )?.cmd ??
-      OSCILLATION_KEYS.find((key) => key in state) ??
-      'none';
+    this.currState.swingCMD = getOscillationCommand(
+      accessory.context.device,
+      state,
+    ) || 'none';
 
     if (this.currState.swingCMD !== 'none') {
       // Register handlers for Swing Mode (oscillation)
@@ -130,14 +136,21 @@ export class FanAccessory extends BaseAccessory {
       this.currState.swing = Boolean(state[this.currState.swingCMD]?.state ?? false);
     }
 
-    // Check if mode control is supported
-    if (state.mode !== undefined) {
+    // Check if mode control is supported. Newer fans report "windtype"
+    // instead of "mode".
+    const modeCommand = getModeCommand(state);
+    this.currState.modeCMD = modeCommand || 'none';
+    if (modeCommand) {
       // Register handlers for Target Fan State
       this.service
         .getCharacteristic(this.platform.Characteristic.TargetFanState)
         .onSet(this.setMode.bind(this))
         .onGet(this.getMode.bind(this));
-      this.currState.autoMode = this.convertModeToBoolean(state.mode.state);
+      this.currState.mode = Number(getStateValue(state, modeCommand));
+      this.currState.autoMode = this.convertModeToBoolean(this.currState.mode);
+      this.configureModeSwitches();
+    } else {
+      this.removeModeSwitches();
     }
 
     // Check if child lock is supported
@@ -149,6 +162,8 @@ export class FanAccessory extends BaseAccessory {
         .onGet(this.getLockPhysicalControls.bind(this));
       this.currState.lockPhysicalControls = Boolean(state.childlockon.state);
     }
+
+    this.configurePreferenceSwitches(state);
 
     const shouldHideTemperatureSensor =
       this.platform.config.hideTemperatureSensor || false; // default to false if not defined
@@ -279,15 +294,23 @@ export class FanAccessory extends BaseAccessory {
                 );
                 break;
               case 'mode':
-                this.currState.autoMode = this.convertModeToBoolean(
-                  data.reported.mode,
-                );
-                this.service
-                  .getCharacteristic(
-                    this.platform.Characteristic.TargetFanState,
-                  )
-                  .updateValue(this.currState.autoMode);
-                this.platform.log.debug('Fan mode:', data.reported.mode);
+              case 'windtype':
+                this.updateMode(Number(data.reported[key]));
+                this.platform.log.debug('Fan mode:', data.reported[key]);
+                break;
+              case 'ledalwayson':
+                this.currState.ledAlwaysOn = Boolean(data.reported.ledalwayson);
+                this.displayAutoOffService
+                  ?.getCharacteristic(this.platform.Characteristic.On)
+                  .updateValue(!this.currState.ledAlwaysOn);
+                this.platform.log.debug('Display always on:', data.reported.ledalwayson);
+                break;
+              case 'voiceon':
+                this.currState.panelSound = Boolean(data.reported.voiceon);
+                this.panelSoundService
+                  ?.getCharacteristic(this.platform.Characteristic.On)
+                  .updateValue(this.currState.panelSound);
+                this.platform.log.debug('Panel sound:', data.reported.voiceon);
                 break;
               case 'childlockon':
                 this.currState.lockPhysicalControls = Boolean(
@@ -351,6 +374,115 @@ export class FanAccessory extends BaseAccessory {
     });
   }
 
+  private configureModeSwitches() {
+    if (!this.platform.config.exposeFanModeSwitches) {
+      this.removeModeSwitches();
+      return;
+    }
+
+    for (const mode of FAN_MODE_SWITCHES) {
+      const displayName = `${this.accessory.context.device.deviceName} ${mode.name}`;
+      const service = this.accessory.getServiceById(
+        this.platform.Service.Switch,
+        mode.subtype,
+      ) || this.accessory.addService(
+          this.platform.Service.Switch,
+          displayName,
+          mode.subtype,
+        );
+
+      service.displayName = displayName;
+      service
+        .setCharacteristic(this.platform.Characteristic.Name, displayName)
+        .getCharacteristic(this.platform.Characteristic.On)
+        .onSet((value) => this.setDetailedMode(mode.value, value))
+        .onGet(() => this.currState.mode === mode.value)
+        .updateValue(this.currState.mode === mode.value);
+
+      this.modeServices.set(mode.value, service);
+    }
+  }
+
+  private removeModeSwitches() {
+    for (const mode of FAN_MODE_SWITCHES) {
+      const service = this.accessory.getServiceById(
+        this.platform.Service.Switch,
+        mode.subtype,
+      );
+      if (service) {
+        this.accessory.removeService(service);
+      }
+    }
+    this.modeServices.clear();
+  }
+
+  private configurePreferenceSwitches(state) {
+    if (!this.platform.config.exposeFanPreferences) {
+      this.removeSwitch('dreo-display-auto-off');
+      this.removeSwitch('dreo-panel-sound');
+      this.displayAutoOffService = undefined;
+      this.panelSoundService = undefined;
+      return;
+    }
+
+    const deviceName = this.accessory.context.device.deviceName;
+    if (state.ledalwayson !== undefined) {
+      this.currState.ledAlwaysOn = Boolean(state.ledalwayson.state);
+      const displayName = `${deviceName} Display Auto Off`;
+      this.displayAutoOffService = this.accessory.getServiceById(
+        this.platform.Service.Switch,
+        'dreo-display-auto-off',
+      ) || this.accessory.addService(
+          this.platform.Service.Switch,
+          displayName,
+          'dreo-display-auto-off',
+        );
+      this.displayAutoOffService.displayName = displayName;
+      this.displayAutoOffService
+        .setCharacteristic(this.platform.Characteristic.Name, displayName)
+        .getCharacteristic(this.platform.Characteristic.On)
+        .onSet(this.setDisplayAutoOff.bind(this))
+        .onGet(this.getDisplayAutoOff.bind(this))
+        .updateValue(!this.currState.ledAlwaysOn);
+    } else {
+      this.removeSwitch('dreo-display-auto-off');
+      this.displayAutoOffService = undefined;
+    }
+
+    if (state.voiceon !== undefined) {
+      this.currState.panelSound = Boolean(state.voiceon.state);
+      const displayName = `${deviceName} Panel Sound`;
+      this.panelSoundService = this.accessory.getServiceById(
+        this.platform.Service.Switch,
+        'dreo-panel-sound',
+      ) || this.accessory.addService(
+          this.platform.Service.Switch,
+          displayName,
+          'dreo-panel-sound',
+        );
+      this.panelSoundService.displayName = displayName;
+      this.panelSoundService
+        .setCharacteristic(this.platform.Characteristic.Name, displayName)
+        .getCharacteristic(this.platform.Characteristic.On)
+        .onSet(this.setPanelSound.bind(this))
+        .onGet(this.getPanelSound.bind(this))
+        .updateValue(this.currState.panelSound);
+    } else {
+      this.removeSwitch('dreo-panel-sound');
+      this.panelSoundService = undefined;
+    }
+  }
+
+  private removeSwitch(subtype: string) {
+    const service = this.accessory.getServiceById(
+      this.platform.Service.Switch,
+      subtype,
+    );
+    if (service) {
+      this.accessory.removeService(service);
+    }
+  }
+
   // Handle requests to set the "Active" characteristic
   setActive(value) {
     this.platform.log.debug('Triggered SET Active:', value);
@@ -402,12 +534,62 @@ export class FanAccessory extends BaseAccessory {
   // Set fan mode
   async setMode(value) {
     this.platform.webHelper.control(this.sn, {
-      mode: value === this.platform.Characteristic.TargetFanState.AUTO ? 4 : 1,
+      [this.currState.modeCMD]:
+        value === this.platform.Characteristic.TargetFanState.AUTO ? 4 : 1,
     });
   }
 
   async getMode() {
     return this.currState.autoMode;
+  }
+
+  private setDetailedMode(mode: number, value: CharacteristicValue) {
+    if (Boolean(value)) {
+      this.platform.webHelper.control(this.sn, {
+        [this.currState.modeCMD]: mode,
+      });
+      return;
+    }
+
+    if (this.currState.mode === mode) {
+      this.platform.webHelper.control(this.sn, {
+        [this.currState.modeCMD]: 1,
+      });
+    }
+  }
+
+  private updateMode(mode: number) {
+    this.currState.mode = mode;
+    this.currState.autoMode = this.convertModeToBoolean(mode);
+    this.service
+      .getCharacteristic(this.platform.Characteristic.TargetFanState)
+      .updateValue(this.currState.autoMode);
+
+    for (const [modeValue, service] of this.modeServices) {
+      service
+        .getCharacteristic(this.platform.Characteristic.On)
+        .updateValue(modeValue === mode);
+    }
+  }
+
+  private setDisplayAutoOff(value: CharacteristicValue) {
+    this.platform.webHelper.control(this.sn, {
+      ledalwayson: !Boolean(value),
+    });
+  }
+
+  private getDisplayAutoOff() {
+    return !this.currState.ledAlwaysOn;
+  }
+
+  private setPanelSound(value: CharacteristicValue) {
+    this.platform.webHelper.control(this.sn, {
+      voiceon: Boolean(value),
+    });
+  }
+
+  private getPanelSound() {
+    return this.currState.panelSound;
   }
 
   // Turn child lock on/off

--- a/src/accessories/FanCapabilities.ts
+++ b/src/accessories/FanCapabilities.ts
@@ -1,0 +1,56 @@
+interface FanControl {
+  type?: string;
+  cmd?: string;
+}
+
+interface FanDevice {
+  model?: string;
+  controlsConf?: {
+    control?: unknown;
+  };
+}
+
+interface FanStateValue {
+  state?: unknown;
+}
+
+export type FanState = Record<string, FanStateValue | undefined>;
+
+export const FAN_MODE_SWITCHES = [
+  { value: 2, name: 'Natural Breeze', subtype: 'dreo-mode-natural' },
+  { value: 3, name: 'Sleep Mode', subtype: 'dreo-mode-sleep' },
+] as const;
+
+const OSCILLATION_KEYS = ['shakehorizon', 'hoscon', 'oscmode'] as const;
+
+// Some devices omit both controlsConf and the oscillation field from their
+// initial state. Keep confirmed model-specific fallbacks narrowly scoped.
+const OSCILLATION_FALLBACKS: Record<string, string> = {
+  'DR-HTF017S': 'shakehorizon',
+};
+
+function getControls(device: FanDevice): FanControl[] {
+  const controls = device.controlsConf?.control;
+  return Array.isArray(controls) ? controls : [];
+}
+
+export function getOscillationCommand(
+  device: FanDevice,
+  state: FanState,
+): string | undefined {
+  const configuredCommand = getControls(device).find(
+    (control) => control.type === 'Oscillation',
+  )?.cmd;
+
+  return configuredCommand ||
+    OSCILLATION_KEYS.find((command) => state[command] !== undefined) ||
+    OSCILLATION_FALLBACKS[device.model || ''];
+}
+
+export function getModeCommand(state: FanState): string | undefined {
+  return ['windtype', 'mode'].find((command) => state[command] !== undefined);
+}
+
+export function getStateValue(state: FanState, command: string): unknown {
+  return state[command]?.state;
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -136,6 +136,10 @@ export class DreoPlatform implements DynamicPlatformPlugin {
         // The accessory already exists
         this.log.info('Restoring existing accessory from cache:', device.deviceName);
         accessory = existingAccessory;
+        // Refresh cloud metadata on every discovery. This keeps capabilities and
+        // service labels current after a device is renamed in the Dreo app.
+        accessory.context.device = device;
+        accessory.displayName = device.deviceName;
       } else {
         // The accessory does not yet exist, so we need to create it
         this.log.info('Adding new accessory:', device.deviceName);
@@ -210,6 +214,8 @@ export class DreoPlatform implements DynamicPlatformPlugin {
       if (!existingAccessory && modelPrefix) {
         // Link accessory to the platform if model is supported
         this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+      } else if (existingAccessory && modelPrefix) {
+        this.api.updatePlatformAccessories([accessory]);
       }
     }
   }

--- a/test/FanCapabilities.test.js
+++ b/test/FanCapabilities.test.js
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  FAN_MODE_SWITCHES,
+  getModeCommand,
+  getOscillationCommand,
+  getStateValue,
+} = require('../dist/accessories/FanCapabilities');
+
+test('uses oscillation capability metadata when available', () => {
+  const device = {
+    controlsConf: {
+      control: [{ type: 'Oscillation', cmd: 'hoscon' }],
+    },
+  };
+
+  assert.strictEqual(getOscillationCommand(device, {}), 'hoscon');
+});
+
+test('detects known oscillation commands from live state', () => {
+  const device = { controlsConf: {} };
+
+  assert.strictEqual(
+    getOscillationCommand(device, { shakehorizon: { state: false } }),
+    'shakehorizon',
+  );
+  assert.strictEqual(
+    getOscillationCommand(device, { hoscon: { state: false } }),
+    'hoscon',
+  );
+  assert.strictEqual(
+    getOscillationCommand(device, { oscmode: { state: 0 } }),
+    'oscmode',
+  );
+});
+
+test('falls back to shakehorizon for DR-HTF017S', () => {
+  assert.strictEqual(
+    getOscillationCommand({ model: 'DR-HTF017S', controlsConf: {} }, {}),
+    'shakehorizon',
+  );
+});
+
+test('does not invent an oscillation command for unknown devices', () => {
+  assert.strictEqual(getOscillationCommand({}, {}), undefined);
+});
+
+test('supports both fan mode command variants', () => {
+  assert.strictEqual(getModeCommand({ windtype: { state: 2 } }), 'windtype');
+  assert.strictEqual(getModeCommand({ mode: { state: 4 } }), 'mode');
+  assert.strictEqual(getModeCommand({}), undefined);
+  assert.strictEqual(getStateValue({ windtype: { state: 3 } }, 'windtype'), 3);
+});
+
+test('only exposes non-native fan modes as optional switches', () => {
+  assert.deepStrictEqual(
+    FAN_MODE_SWITCHES.map(({ value, name }) => ({ value, name })),
+    [
+      { value: 2, name: 'Natural Breeze' },
+      { value: 3, name: 'Sleep Mode' },
+    ],
+  );
+});
+
+test('additional fan controls are disabled by default', () => {
+  const schema = require('../config.schema.json');
+
+  assert.strictEqual(schema.schema.properties.exposeFanModeSwitches.default, false);
+  assert.strictEqual(schema.schema.properties.exposeFanPreferences.default, false);
+});


### PR DESCRIPTION
## Summary

- add a narrowly scoped `DR-HTF017S` oscillation fallback using the confirmed `shakehorizon` command
- support the `windtype` mode key used by newer fans
- add disabled-by-default switches for Natural/Sleep modes and supported display/sound preferences
- refresh cached Dreo metadata and service labels after devices are renamed

## Why the oscillation fallback is needed

Fan oscillation has historically been discovered from the `Oscillation` entry in `controlsConf.control`. The Dreo API can return an incomplete `controlsConf` payload for the `DR-HTF017S`, leaving the command unset and preventing the `SwingMode` characteristic from being registered.

Current `main` also checks the initial device state for known oscillation keys. That improves dynamic discovery, but it still depends on `shakehorizon` being included in that first response. This change retains both dynamic paths and uses the model fallback only when neither produces a command:

1. API capability metadata
2. initial device state
3. confirmed model fallback (`DR-HTF017S` only)

The `shakehorizon` command has been used successfully with three physical `DR-HTF017S` fans. A regression test covers the incomplete-metadata and incomplete-initial-state case.

## HomeKit behavior

The default presentation remains intentionally small:

- one Fan v2 service
- native oscillation through the fan's `SwingMode` setting
- the existing temperature sensor, unless hidden in configuration

No extra switch services are added by default. Users can independently opt into:

- `exposeFanModeSwitches`: Natural Breeze and Sleep Mode
- `exposeFanPreferences`: supported Display Auto Off and Panel Sound controls

Optional service names include the Dreo device name so controls remain distinguishable when an account contains multiple fans. Normal and Auto are not duplicated as switches because HomeKit already represents them through `TargetFanState`.

## Scope

This does not introduce a static capability database or replace dynamic capability discovery. It also keeps oscillation on the native Fan v2 service rather than publishing a separate oscillation switch. The only model-specific capability is the observed `DR-HTF017S` fallback.

Related to #72.

## Verification

- `npm test` — 16 passing tests
- `npm run lint`
- `git diff --check`
